### PR TITLE
Fix typo in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY /docker/docker-entrypoint.sh /app/docker/
 RUN chmod +x /app/docker/superset-entrypoint.sh
 RUN chmod +x /app/docker/docker-entrypoint.sh
 RUN chmod +x /app/docker/docker-init.sh
-RUN chmod +x /app/docker/docker-bootstrap.s
+RUN chmod +x /app/docker/docker-bootstrap.sh
 
 # We switch back to the `superset` user
 USER superset


### PR DESCRIPTION
The `/app/docker/docker-bootstrap.sh` was missing the `h` causing `make build_init` to fail with ` => ERROR [superset-image_superset 15/15] RUN chmod +x /app/docker/docker-bootstrap.s`